### PR TITLE
Update docs and add PAT support to changelog script

### DIFF
--- a/release-management/create-changelog/changelog.py
+++ b/release-management/create-changelog/changelog.py
@@ -9,7 +9,7 @@ URL = 'https://api.github.com/repos/opencast/opencast/pulls' \
 JIRA_TICKET_URL = 'https://opencast.jira.com/browse/'
 
 
-def main(branch, start_date, end_date):
+def main(branch, start_date, end_date, pat):
     begin = parse(start_date).replace(tzinfo=None)
     end = parse(end_date).replace(tzinfo=None) if end_date else datetime.now()
     next_url = URL + branch
@@ -17,7 +17,13 @@ def main(branch, start_date, end_date):
 
     # get all closed pull request for a specific branch
     while next_url:
-        r = requests.get(next_url)
+        r = None
+        if None != pat:
+            r = requests.get(next_url)
+        else:
+            r = requests.get(next_url, headers = {
+                  "Authorization": "Bearer " + pat,
+            })
         link_header = r.headers.get('Link')
         next_url = None
         if link_header:
@@ -46,13 +52,16 @@ def pretty_print(title, pr_number, pr_link):
 
 if __name__ == '__main__':
     argc = len(sys.argv)
-    if 3 <= argc <= 4:
+    if 3 <= argc <= 5:
         branch = sys.argv[1]
         start_date = sys.argv[2]
         end_date = None
-        if argc == 4:
+        pat = None
+        if argc >= 4:
             end_date = sys.argv[3]
+        if argc == 5:
+            pat = sys.argv[4]
 
-        main(branch, start_date, end_date)
+        main(branch, start_date, end_date, pat)
     else:
-        print('Usage: %s branch start-date [end-date]' % sys.argv[0])
+        print('Usage: %s branch start-date [end-date] [github pat]' % sys.argv[0])

--- a/release-management/create-changelog/readme.md
+++ b/release-management/create-changelog/readme.md
@@ -5,27 +5,57 @@ This script generated a changelog based on merged pull requests. To generate a
 changelog for a given version, run the script with the git branch name, start
 date and optionally end date as arguments.
 
-
-Example for 4.x
+Example for 14.x
 ---------------
 
 ```
-% python changelog.py r/4.x 2018-03-29                                                                                                                       (git)-[master] [148] 
-- [MH-12923 serviceregistry initializes a db connection twice
-  ](https://github.com/opencast/opencast/pull/267)
-...
+- [[#4945](https://github.com/opencast/opencast/pull/4945)] -
+  Drop orphan statistics database index
 ```
 
-For version 4.0 you would additionally add the changes listed by
+Changelog for N.x version
+-------------------------
 
-    % python3 changelog.py develop 2017-09-22 2018-04-03
+    python changelog.py r/N.x <N.x-branch-cut-date>
 
-
-Changelog for x.0 version
+Changelog for N.0 version
 -------------------------
 
 Since these versions are developed on both `develop` and their specific release
 branched, two requests need to be made and merged:
 
-    % python changelog.py develop <begin-of-development> <x.0-branch-cut-date>
-    % python changelog.py r/5.x <begin-of-development>
+    python changelog.py develop <begin-of-development> <N.x-branch-cut-date>
+    python changelog.py r/N.x <N.x-branch-cut-date>
+
+Note that the Github API may generate duplicate entries between the two lists depending on dates and timezones.
+
+Dates
+-----
+Computing the dates can be annoying.  You need to find the earliest commit belonging to various combinations of branches.
+
+    git log --pretty=%as $(diff -u <(git rev-list --first-parent r/N.x) <(git rev-list --first-parent develop) | sed -ne 's/^ //p' | head -1)
+
+As an example, to generate the full list for Opencast 14 you need to know
+
+ - The changelog for `develop` between the `r/13.x` branching off, and `r/14.x` being started
+ - The changelog for `r/14.x` up to `14.0`
+
+To find the first begin-of-development date
+
+    git log --pretty=%as $(diff -u <(git rev-list --first-parent r/13.x) <(git rev-list --first-parent develop) | sed -ne 's/^ //p' | head -1)
+
+To find the 14.x branch date
+
+    git log --pretty=%as $(diff -u <(git rev-list --first-parent r/14.x) <(git rev-list --first-parent develop) | sed -ne 's/^ //p' | head -1)
+
+So the final changelog calls would be
+
+    % python changelog.py develop 2022-11-16 2023-05-15
+    % python changelog.py r/14.x 2023-05-15
+
+API Limits
+----------
+
+Github enforces API limits, which this script can easily hit - especially if you run it multiple times when debugging!
+To raise this limit, you may need to create a Personal Access Token with appropriate permissions (read only to the
+upstream repo), and pass that as the *fifth* parameter.

--- a/whisper-AI-exec-script/whisper-getvtt.sh
+++ b/whisper-AI-exec-script/whisper-getvtt.sh
@@ -12,12 +12,12 @@ ffmpeg -y -nostdin -nostats -i "$videoFile" -vn -acodec copy "/tmp/$eventId.aac"
 if [[ "$translate" == "translate" ]]
 then
     echo "Translating into english"
-    curl --max-time 7200 --location --request POST "$whisperServer/get-vtt?task=translate" \
+    curl --max-time 7200 --location --request POST "$whisperServer/asr?task=translate&output=vtt" \
     --form 'audio_file=@"/tmp/'"$eventId"'.aac"' -o "$outputVTT"
 else
     # Send audio for transcription
     echo "Transcribing audio"
-    curl --max-time 7200 --location --request POST "$whisperServer/get-vtt?task=transcribe" \
+    curl --max-time 7200 --location --request POST "$whisperServer/asr?task=transcribe&output=vtt" \
     --form 'audio_file=@"/tmp/'"$eventId"'.aac"' -o "$outputVTT"
 fi
 


### PR DESCRIPTION
This PR:
- Updates the documentation in the changelog script to clarify how to actually use it for less technically inclined RMs.
- Adds support for specifying PATs on the commandline to the script.
